### PR TITLE
Continuous Documentation to Zeit Now via Github Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Continuous Documentation
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout current git repository
+      uses: actions/checkout@v1
+
+    - name: Include $CONDA in $PATH
+      run: echo ::add-path::$CONDA/bin
+
+    - name: Install conda packages and pygmt
+      run: |
+        conda env create -f environment.yml
+        source activate pygmt
+        conda install -c conda-forge -c conda-forge/label/dev gmt==6.0.0rc4
+        make install
+
+    - name: Build documentation pages
+      run: |
+        source activate pygmt
+        cd doc
+        make all
+
+    - name: Deploy website to Zeit Now
+      run: now --name pygmt --token $NOW_TOKEN doc/_build/html
+      env:
+        NOW_TOKEN: ${{ secrets.NOW_TOKEN }}


### PR DESCRIPTION
**Description of proposed changes**

This Github-Actions method works, but requires using a secret token that can be hard to manage. Superseding it by using a `package.json` file instead. Just recording it here for historical reasons. 

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

Continuous documentation using Github Actions on every push made to the repository. Sets up conda first, installs the necessary packages, builds the documentation pages and then deploys website to Zeit Now static site host using secret token.

<!-- If fixing an issue, put the issue number after the # below (no spaces). Github will automatically close it when this gets merged. -->
Fixes #


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to docstrings or tutorials.
